### PR TITLE
fix #21 process_scryfall_data result value when all cards are missing arena_id

### DIFF
--- a/file_extractor.py
+++ b/file_extractor.py
@@ -1010,12 +1010,11 @@ class FileExtractor:
                     self.card_dict[arena_id][constants.DATA_SECTION_IMAGES] = [
                         card_data["image_uris"]["normal"]]
 
-                result = True
-
             except Exception as error:
                 file_logger.info("_process_scryfall_data Error: %s", error)
                 result_string = error
 
+            result = True
         return result, result_string
 
     def _process_card_data(self, card):


### PR DESCRIPTION
For some reason I cannot "@" bikeboy99, but he provided the troubleshooting for this issue.

scryfall datasets contain all versions of cards, some of which are not available on MTGA, in which case they do not have the arena_id property, for example:
MTGA version of "Danitha, Benalia's Hope" (has arena_id):
https://api.scryfall.com/cards/845e5663-2959-44ae-b4c6-d6ea41f01d6e?format=json&pretty=true
non-MTGA version of "Danitha, Benalia's Hope" (does not have arena_id):
https://api.scryfall.com/cards/26070716-4860-4137-8316-083baef1faad?format=json&pretty=true

#21 occurs because the last page of DMU cards are all non-MTGA versions.
When this occurs, result from process_scryfall_data is never set to True, because zero of the cards ever get processed.
The assignment logic for result is already a bit loose, because as long as at least one card is correctly processed, result will be set to True, regardless of whether an exception occurs afterwards.  I did not attempt to improve this.
In order to fix this case, I moved the assignment of result outside of the loop, which preserves the spirit of the current logic without improving it.