### PR TITLE
added locations for the mtga card db for linux systems

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -184,6 +184,16 @@ LOCAL_DATA_FOLDER_PATH_WINDOWS = os.path.join(
     "Wizards of the Coast", "MTGA", "MTGA_Data")
 LOCAL_DATA_FOLDER_PATH_OSX = os.path.join(
     "Library", "Application Support", "com.wizards.mtga")
+LOCAL_DATA_FOLDER_PATH_LINUX = next(filter(os.path.exists, [
+    # Steam
+    os.path.join(os.path.expanduser("~"), ".local", "share", "Steam", "steamapps", "common", "MTGA", "MTGA_Data"),
+
+    # Lutris
+    os.path.join(os.path.expanduser("~"), "Games", "magic-the-gathering-arena", "drive_c", "Program Files", "Wizards of the Coast", "MTGA", "MTGA_Data"),
+
+    # Bottles
+    os.path.join(os.path.expanduser("~"), ".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles", "MTG-Arena", "drive_c", "Program Files", "Wizards of the Coast", "MTGA", "MTGA_Data")
+    ]), None)
 
 LOCAL_DOWNLOADS_DATA = os.path.join("Downloads", "Raw")
 
@@ -255,6 +265,7 @@ SCRYFALL_REQUEST_ATTEMPT_MAX = 5
 
 PLATFORM_ID_OSX = "darwin"
 PLATFORM_ID_WINDOWS = "win32"
+PLATFORM_ID_LINUX = "linux"
 
 LOG_NAME = "Player.log"
 

--- a/src/file_extractor.py
+++ b/src/file_extractor.py
@@ -408,6 +408,10 @@ class FileExtractor:
             directory = os.path.join(os.path.expanduser('~'),
                                      constants.LOCAL_DATA_FOLDER_PATH_OSX) if not self.directory else self.directory
             paths = [os.path.join(directory, constants.LOCAL_DOWNLOADS_DATA)]
+        elif sys.platform == constants.PLATFORM_ID_LINUX:
+            if constants.LOCAL_DATA_FOLDER_PATH_LINUX:
+                directory = constants.LOCAL_DATA_FOLDER_PATH_LINUX
+                paths = [os.path.join(directory, constants.LOCAL_DOWNLOADS_DATA)]
         else:
             if not self.directory:
                 path_list = [constants.WINDOWS_DRIVES, constants.WINDOWS_PROGRAM_FILES, [


### PR DESCRIPTION
On Linux systems, the application doesn't seem to attempt to load the local MTGA database.  This forces the Scryfall backup method to get the card data, which:

- Triggers unnecessary API calls to Scryfall
- Seems to not handle Adventure cards from Wilds of Eldraine properly - this is a separate issue, but loading the MTGA database does appear to fix the problem

This change points the application to the proper MTGA install location if Steam, Lutris, or Bottles was used to install MTGA (in that order, if multiple installations exist).